### PR TITLE
add updated lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Install dependencies
         run: go mod tidy
 
+      - name: Cache GolangCI-Lint
+        uses: actions/cache@v3
+        continue-on-error: true
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:


### PR DESCRIPTION
Makes the workflow a bit more robust when cache service is not available.